### PR TITLE
Align Line No. Right by Default

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ Insert formatted text with number at selected area.
 You can select "text format", "starting number", and "insert area".
 
 Default value of option are
-text format     : "%d "
+text format     : "%<N>d " (where <N> is 3 or the max length of the line numbers)
 starting number : 1
 insert area     : current line only
 

--- a/plugin/catn.vim
+++ b/plugin/catn.vim
@@ -8,13 +8,26 @@
 
 " judge argument count
 :function! s:Catn(...) range
-    :if len(a:000) == 0
-        :call s:CatnFormat("%d ", 1, a:firstline, a:lastline)
-    :elseif len(a:000) == 1
-        :call s:CatnFormat("%d ", a:1, a:firstline, a:lastline)
-    :else
-        :call s:CatnFormat(a:1, a:2, a:firstline, a:lastline)
+    :let l:format = v:null
+    :let l:numbegin = v:null
+
+    :if len(a:000) == 1
+        :let l:numbegin = a:1
+    :elseif len(a:000) >= 2
+        :let l:format = a:1
+        :let l:numbegin = a:2
     :endif
+
+    :if l:numbegin == v:null
+        :let l:numbegin = 1
+    :endif
+
+    :if l:format == v:null
+        :let l:maxnumwidth = max([3] + map([l:numbegin, printf("%d", a:lastline - a:firstline + l:numbegin)], { _, val -> len(val) }))
+        :let l:format = "%" . l:maxnumwidth . "d "
+    :endif
+
+    :call s:CatnFormat(l:format, l:numbegin, a:firstline, a:lastline)
 :endfunction
 
 " insert formated text at left end
@@ -52,7 +65,7 @@ Insert formatted text with number at selected area.
 You can select "text format", "starting number", and "insert area".
 
 Default value of option are
-text format     : "%d "
+text format     : "%<N>d " (where <N> is 3 or the max length of the line numbers)
 starting number : 1
 insert area     : current line only
 


### PR DESCRIPTION
By default format `%d `, line numbers are not get aligned if number width is not the same all.

So fixed it to be aligned with the default format modification.

Also, I changed the default minimum line number width to be 3, as vim `&number` format is so.

----

### Sample

#### `:Catn` / `:Catn 1`

```
  1 Line_01
  2 Line_02
  3 Line_03
  4 Line_04
  5 Line_05
  6 Line_06
  7 Line_07
  8 Line_08
  9 Line_09
 10 Line_10
 11 Line_11
 12 Line_12
 13 Line_13
 14 Line_14
 15 Line_15
```

#### `:Catn 995`

```
 995 Line_01
 996 Line_02
 997 Line_03
 998 Line_04
 999 Line_05
1000 Line_06
1001 Line_07
1002 Line_08
1003 Line_09
1004 Line_10
1005 Line_11
1006 Line_12
1007 Line_13
1008 Line_14
1009 Line_15
```

#### `:Catn -100`

```
-100 Line_01
 -99 Line_02
 -98 Line_03
 -97 Line_04
 -96 Line_05
 -95 Line_06
 -94 Line_07
 -93 Line_08
 -92 Line_09
 -91 Line_10
 -90 Line_11
 -89 Line_12
 -88 Line_13
 -87 Line_14
 -86 Line_15
```
